### PR TITLE
Restructure survey all display to include owner name as a link

### DIFF
--- a/app/views/all_surveys.erb
+++ b/app/views/all_surveys.erb
@@ -1,3 +1,8 @@
-<% @surveys.each do |survey| %>
-  <p><a href="/surveys/<%="#{survey.id}"%>"><%=survey.title%></a><p>
-<% end %>
+<ol>
+  <% @surveys.each do |survey| %>
+    <li>
+    <a href="/surveys/<%="#{survey.id}"%>"><%=survey.title%></a>
+    <a href="/users/<%="#{survey.user_id}"%>"><%=survey.user.name%></a>
+  </li>
+  <% end %>
+</ol>


### PR DESCRIPTION
This just alters the display of all surveys to be an ordered list to include a link to the survey and a link to the user page of the owner of each survey.